### PR TITLE
Add cli param to build with different css path prefixes

### DIFF
--- a/build.js
+++ b/build.js
@@ -50,6 +50,10 @@ const config = merge(
 
 const styleDictionary = StyleDictionary.extend(config);
 
+if (argv.cssUrlPrefix) {
+	styleDictionary.properties.system.config.cssUrlPrefix.value = argv.cssUrlPrefix;
+}
+
 if (argv.platform) {
 	if (config.platforms[argv.platform]) {
 		styleDictionary.buildPlatform(argv.platform);

--- a/dictionary/properties/color/system.yaml
+++ b/dictionary/properties/color/system.yaml
@@ -1,5 +1,5 @@
 color:
-  system:
+  system: # Not to be confused with the `system.config` properties
     black:
       value: '#000000'
 

--- a/dictionary/properties/font/font-face.yaml
+++ b/dictionary/properties/font/font-face.yaml
@@ -5,83 +5,83 @@ asset:
         normal:
           value: dictionary/assets/fonts/inconsolata/inconsolata-regular.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/inconsolata/inconsolata-regular.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/inconsolata/inconsolata-regular.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/inconsolata/inconsolata-regular.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/inconsolata/inconsolata-regular.woff'
 
       700:
         normal:
           value: dictionary/assets/fonts/inconsolata/inconsolata-bold.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/inconsolata/inconsolata-bold.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/inconsolata/inconsolata-bold.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/inconsolata/inconsolata-bold.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/inconsolata/inconsolata-bold.woff'
 
     Open Sans:
       300:
         normal:
           value: dictionary/assets/fonts/open-sans/opensans-light.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/open-sans/opensans-light.woff2'
-            woff:  '{system.config.cssUrlPrefix.value}/open-sans/opensans-light.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-light.woff2'
+            woff:  '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-light.woff'
 
       400:
         normal:
           value: dictionary/assets/fonts/open-sans/opensans-regular.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/open-sans/opensans-regular.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/open-sans/opensans-regular.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-regular.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-regular.woff'
 
         italic:
           value: dictionary/assets/fonts/open-sans/opensans-italic.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/open-sans/opensans-italic.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/open-sans/opensans-italic.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-italic.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-italic.woff'
 
       600:
         normal:
           value: dictionary/assets/fonts/open-sans/opensans-semibold.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/open-sans/opensans-semibold.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/open-sans/opensans-semibold.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-semibold.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-semibold.woff'
 
       700:
         normal:
           value: dictionary/assets/fonts/open-sans/opensans-bold.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/open-sans/opensans-bold.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/open-sans/opensans-bold.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-bold.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-bold.woff'
 
       800:
         normal:
           value: dictionary/assets/fonts/open-sans/opensans-extrabold.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/open-sans/opensans-extrabold.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/open-sans/opensans-extrabold.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-extrabold.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/open-sans/opensans-extrabold.woff'
 
     Lato:
       300:
         normal:
           value: dictionary/assets/fonts/lato/lato-light.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/lato/lato-light.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/lato/lato-light.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/lato/lato-light.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/lato/lato-light.woff'
 
       400:
         normal:
           value: dictionary/assets/fonts/lato/lato-regular.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/lato/lato-regular.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/lato/lato-regular.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/lato/lato-regular.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/lato/lato-regular.woff'
 
       700:
         normal:
           value: dictionary/assets/fonts/lato/lato-bold.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/lato/lato-bold.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/lato/lato-bold.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/lato/lato-bold.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/lato/lato-bold.woff'
 
       900:
         normal:
           value: dictionary/assets/fonts/lato/lato-black.ttf
           formats:
-            woff2: '{system.config.cssUrlPrefix.value}/lato/lato-black.woff2'
-            woff: '{system.config.cssUrlPrefix.value}/lato/lato-black.woff'
+            woff2: '{system.config.cssUrlPrefix.value}/fonts/lato/lato-black.woff2'
+            woff: '{system.config.cssUrlPrefix.value}/fonts/lato/lato-black.woff'

--- a/dictionary/properties/system.yaml
+++ b/dictionary/properties/system.yaml
@@ -1,4 +1,4 @@
-system:
+system: # not to be confused with the `color.system` properties
   config:
     cssUrlPrefix:
-      value: '../fonts'
+      value: '..'

--- a/dist/css/brand-colors.css
+++ b/dist/css/brand-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 :root {

--- a/dist/css/code-colors.css
+++ b/dist/css/code-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 :root {

--- a/dist/css/font-vars.css
+++ b/dist/css/font-vars.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 :root {

--- a/dist/css/system-colors.css
+++ b/dist/css/system-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 :root {

--- a/dist/js/brand-colors.esm.js
+++ b/dist/js/brand-colors.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 export const dsColorBrandDahlia = "#ec0041";

--- a/dist/js/code-colors.esm.js
+++ b/dist/js/code-colors.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 export const dsColorCodeBackground = "#2f3542";

--- a/dist/js/data-colors.esm.js
+++ b/dist/js/data-colors.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 export const dsColorRampDataHueBlue3 = ["#0073b3","#62b4d9","#bef5ff"];

--- a/dist/js/system-colors.esm.js
+++ b/dist/js/system-colors.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 export const dsColorSystemBlack = "#000000";

--- a/dist/less/brand-colors.less
+++ b/dist/less/brand-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 @ds-color-brand-dahlia: #ec0041;

--- a/dist/less/code-colors.less
+++ b/dist/less/code-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 @ds-color-code-background: #2f3542;

--- a/dist/less/component/button.less
+++ b/dist/less/component/button.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:40 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:32 GMT
  */
 
 @ds-button-border-radius: 3px;

--- a/dist/less/data-colors.less
+++ b/dist/less/data-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 @ds-color-ramp-data-hue-blue-3: #0073b3,#62b4d9,#bef5ff;

--- a/dist/less/fonts.less
+++ b/dist/less/fonts.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 @ds-global-font-family-base: Arial, sans-serif;

--- a/dist/less/system-colors.less
+++ b/dist/less/system-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 08 Apr 2019 16:29:36 GMT
+ * Generated on Tue, 09 Apr 2019 14:57:26 GMT
  */
 
 @ds-color-system-black: #000000;


### PR DESCRIPTION
This allows for builds to specify the `cssUrlPrefix` option on the command line. For example, when we build for deployment to the CDN:

<pre><code>$ yarn build --cssUrlPrefix="<b>https://hook.jwplayer.com</b>"</code></pre>

This will put the prefix on assets (currently only fonts):
<pre><code>src: url("<b>https://hook.jwplayer.com</b>/fonts/inconsolata/inconsolata-regular.woff2")</code></pre>

I would like to make it so more robust overrides are easier through the command line but this will do for our needs at this time.