### PR TITLE
Clean up names and export types

### DIFF
--- a/config/css.yaml
+++ b/config/css.yaml
@@ -11,6 +11,13 @@ platforms:
             category: color
             type: brand
 
+      - destination: data-colors.css
+        format: css/variables
+        filter:
+          attributes:
+            category: color
+            type: data
+
       - destination: system-colors.css
         format: css/variables
         filter:
@@ -31,6 +38,12 @@ platforms:
           attributes:
             category: global
             type: font
+
+      - destination: layout.css
+        format: css/variables
+        filter:
+          attributes:
+            category: layout
 
       - destination: theme.css
         format: css/variables

--- a/config/js.yaml
+++ b/config/js.yaml
@@ -4,9 +4,50 @@ platforms:
     transformGroup: js
     prefix: ds
     files:
+      - destination: brand-colors.esm.js
+        format: javascript/es6
+        filter:
+          attributes:
+            category: color
+            type: brand
+
       - destination: data-colors.esm.js
         format: javascript/es6
         filter:
           attributes:
             category: color
-            type: ramp
+            type: data
+
+      - destination: system-colors.esm.js
+        format: javascript/es6
+        filter:
+          attributes:
+            category: color
+            type: system
+
+      - destination: code-colors.esm.js
+        format: javascript/es6
+        filter:
+          attributes:
+            category: color
+            type: code
+
+      - destination: font-vars.esm.js
+        format: javascript/es6
+        filter:
+          attributes:
+            category: global
+            type: font
+
+      - destination: layout.esm.js
+        format: javascript/es6
+        filter:
+          attributes:
+            category: layout
+
+      - destination: theme.esm.js
+        format: javascript/es6
+        filter:
+          attributes:
+            category: theme
+

--- a/config/js.yaml
+++ b/config/js.yaml
@@ -16,7 +16,7 @@ platforms:
         filter:
           attributes:
             category: color
-            type: data
+            type: ramp
 
       - destination: system-colors.esm.js
         format: javascript/es6

--- a/config/less.yaml
+++ b/config/less.yaml
@@ -32,7 +32,7 @@ platforms:
             category: color
             type: code
 
-      - destination: fonts.less
+      - destination: font-vars.less
         format: less/variables
         filter:
           attributes:

--- a/config/scss.yaml
+++ b/config/scss.yaml
@@ -32,7 +32,7 @@ platforms:
             category: color
             type: code
 
-      - destination: fonts.scss
+      - destination: font-vars.scss
         format: scss/variables
         filter:
           attributes:

--- a/dist/css/brand-colors.css
+++ b/dist/css/brand-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 :root {

--- a/dist/css/brand-colors.css
+++ b/dist/css/brand-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 :root {

--- a/dist/css/code-colors.css
+++ b/dist/css/code-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 :root {

--- a/dist/css/code-colors.css
+++ b/dist/css/code-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 :root {

--- a/dist/css/data-colors.css
+++ b/dist/css/data-colors.css
@@ -1,0 +1,58 @@
+/**
+ * Do not edit directly
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ */
+
+:root {
+ --ds-color-data-hue-blue-1: #0073b3;
+ --ds-color-data-hue-blue-2: #2e8dc3;
+ --ds-color-data-hue-blue-3: #51a7d2;
+ --ds-color-data-hue-blue-4: #74c1e0;
+ --ds-color-data-hue-blue-5: #98dbef;
+ --ds-color-data-hue-blue-6: #bef5ff;
+ --ds-color-data-hue-green-1: #459036;
+ --ds-color-data-hue-green-2: #64a652;
+ --ds-color-data-hue-green-3: #82bb6f;
+ --ds-color-data-hue-green-4: #9fd28c;
+ --ds-color-data-hue-green-5: #bce8aa;
+ --ds-color-data-hue-green-6: #daffc9;
+ --ds-color-data-hue-red-1: #cd3138;
+ --ds-color-data-hue-red-2: #da5550;
+ --ds-color-data-hue-red-3: #e57369;
+ --ds-color-data-hue-red-4: #ef8f84;
+ --ds-color-data-hue-red-5: #f8aba0;
+ --ds-color-data-hue-red-6: #ffc6bd;
+ --ds-color-data-palette-apricot-1: #5a1d7e;
+ --ds-color-data-palette-apricot-2: #9d2076;
+ --ds-color-data-palette-apricot-3: #cb3e69;
+ --ds-color-data-palette-apricot-4: #e86a5c;
+ --ds-color-data-palette-apricot-5: #f69958;
+ --ds-color-data-palette-apricot-6: #f7c966;
+ --ds-color-data-palette-lime-1: #131b60;
+ --ds-color-data-palette-lime-2: #004a93;
+ --ds-color-data-palette-lime-3: #0077ac;
+ --ds-color-data-palette-lime-4: #00a3ac;
+ --ds-color-data-palette-lime-5: #00cb9a;
+ --ds-color-data-palette-lime-6: #a3ee87;
+ --ds-color-data-palette-plum-1: #263995;
+ --ds-color-data-palette-plum-2: #784496;
+ --ds-color-data-palette-plum-3: #a85895;
+ --ds-color-data-palette-plum-4: #ca7396;
+ --ds-color-data-palette-plum-5: #e3949d;
+ --ds-color-data-palette-plum-6: #f7bdad;
+ --ds-color-data-scale-mango-1: #1c7464;
+ --ds-color-data-scale-mango-2: #81b987;
+ --ds-color-data-scale-mango-3: #f1feaf;
+ --ds-color-data-scale-mango-4: #e7b657;
+ --ds-color-data-scale-mango-5: #dc6428;
+ --ds-color-data-scale-pear-1: #c56077;
+ --ds-color-data-scale-pear-2: #e7a491;
+ --ds-color-data-scale-pear-3: #ffead0;
+ --ds-color-data-scale-pear-4: #ecc188;
+ --ds-color-data-scale-pear-5: #d49c44;
+ --ds-color-data-scale-raspberry-1: #04367c;
+ --ds-color-data-scale-raspberry-2: #9a85b9;
+ --ds-color-data-scale-raspberry-3: #ffe8ff;
+ --ds-color-data-scale-raspberry-4: #d584ac;
+ --ds-color-data-scale-raspberry-5: #a40444;
+}

--- a/dist/css/data-colors.css
+++ b/dist/css/data-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 :root {

--- a/dist/css/font-vars.css
+++ b/dist/css/font-vars.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 :root {

--- a/dist/css/font-vars.css
+++ b/dist/css/font-vars.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 :root {

--- a/dist/css/layout.css
+++ b/dist/css/layout.css
@@ -1,0 +1,12 @@
+/**
+ * Do not edit directly
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ */
+
+:root {
+ --ds-layout-size-small: 8px;
+ --ds-layout-size-medium: 16px;
+ --ds-layout-size-large: 24px;
+ --ds-layout-size-extra-large: 32px;
+ --ds-layout-grid-base: 8px;;
+}

--- a/dist/css/layout.css
+++ b/dist/css/layout.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 :root {

--- a/dist/css/system-colors.css
+++ b/dist/css/system-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 :root {

--- a/dist/css/system-colors.css
+++ b/dist/css/system-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 :root {

--- a/dist/css/theme.css
+++ b/dist/css/theme.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 :root {

--- a/dist/css/theme.css
+++ b/dist/css/theme.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 :root {

--- a/dist/js/brand-colors.esm.js
+++ b/dist/js/brand-colors.esm.js
@@ -1,0 +1,21 @@
+/**
+ * Do not edit directly
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ */
+
+export const dsColorBrandDahlia = "#ec0041";
+export const dsColorBrandDahliaFade = "#fbccd9";
+export const dsColorBrandDahliaDark = "#bd0034";
+export const dsColorBrandDahliaDarker = "#a5002e";
+export const dsColorBrandFog = "#d8dde6";
+export const dsColorBrandFogFade = "#f3f5f8";
+export const dsColorBrandFogDark = "#a0acc2";
+export const dsColorBrandFogDarker = "#8797b2";
+export const dsColorBrandMidnight = "#475470";
+export const dsColorBrandMidnightFade = "#dadde2";
+export const dsColorBrandMidnightDark = "#39435a";
+export const dsColorBrandMidnightDarker = "#323b4e";
+export const dsColorBrandAbyss = "#2f3542";
+export const dsColorBrandAbyssFade = "#d5d7d9";
+export const dsColorBrandAbyssDark = "#262a35";
+export const dsColorBrandAbyssDarker = "#21252e";

--- a/dist/js/brand-colors.esm.js
+++ b/dist/js/brand-colors.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 export const dsColorBrandDahlia = "#ec0041";

--- a/dist/js/code-colors.esm.js
+++ b/dist/js/code-colors.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 export const dsColorCodeBackground = "#2f3542";

--- a/dist/js/code-colors.esm.js
+++ b/dist/js/code-colors.esm.js
@@ -1,0 +1,15 @@
+/**
+ * Do not edit directly
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ */
+
+export const dsColorCodeBackground = "#2f3542";
+export const dsColorCodeBackgroundInline = "#f3f5f8";
+export const dsColorCodeText = "#ffffff";
+export const dsColorCodeTextInline = "#2f3542";
+export const dsColorCodeComment = "#8797b2";
+export const dsColorCodeGreen = "#ade087";
+export const dsColorCodePurple = "#ecadff";
+export const dsColorCodeBlue = "#6cbdff";
+export const dsColorCodePink = "#ff949c";
+export const dsColorCodeOrange = "#e5a970";

--- a/dist/js/data-colors.esm.js
+++ b/dist/js/data-colors.esm.js
@@ -1,14 +1,56 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
-export const dsColorRampDataHueBlue = ["#0073b3","#2e8dc3","#51a7d2","#74c1e0","#98dbef","#bef5ff"];
-export const dsColorRampDataHueGreen = ["#459036","#64a652","#82bb6f","#9fd28c","#bce8aa","#daffc9"];
-export const dsColorRampDataHueRed = ["#cd3138","#da5550","#e57369","#ef8f84","#f8aba0","#ffc6bd"];
-export const dsColorRampDataPaletteApricot = ["#5a1d7e","#9d2076","#cb3e69","#e86a5c","#f69958","#f7c966"];
-export const dsColorRampDataPaletteLime = ["#131b60","#004a93","#0077ac","#00a3ac","#00cb9a","#a3ee87"];
-export const dsColorRampDataPalettePlum = ["#263995","#784496","#a85895","#ca7396","#e3949d","#f7bdad"];
-export const dsColorRampDataScaleMango = ["#1c7464","#81b987","#f1feaf","#e7b657","#dc6428"];
-export const dsColorRampDataScalePear = ["#c56077","#e7a491","#ffead0","#ecc188","#d49c44"];
-export const dsColorRampDataScaleRaspberry = ["#04367c","#9a85b9","#ffe8ff","#d584ac","#a40444"];
+export const dsColorDataHueBlue1 = "#0073b3";
+export const dsColorDataHueBlue2 = "#2e8dc3";
+export const dsColorDataHueBlue3 = "#51a7d2";
+export const dsColorDataHueBlue4 = "#74c1e0";
+export const dsColorDataHueBlue5 = "#98dbef";
+export const dsColorDataHueBlue6 = "#bef5ff";
+export const dsColorDataHueGreen1 = "#459036";
+export const dsColorDataHueGreen2 = "#64a652";
+export const dsColorDataHueGreen3 = "#82bb6f";
+export const dsColorDataHueGreen4 = "#9fd28c";
+export const dsColorDataHueGreen5 = "#bce8aa";
+export const dsColorDataHueGreen6 = "#daffc9";
+export const dsColorDataHueRed1 = "#cd3138";
+export const dsColorDataHueRed2 = "#da5550";
+export const dsColorDataHueRed3 = "#e57369";
+export const dsColorDataHueRed4 = "#ef8f84";
+export const dsColorDataHueRed5 = "#f8aba0";
+export const dsColorDataHueRed6 = "#ffc6bd";
+export const dsColorDataPaletteApricot1 = "#5a1d7e";
+export const dsColorDataPaletteApricot2 = "#9d2076";
+export const dsColorDataPaletteApricot3 = "#cb3e69";
+export const dsColorDataPaletteApricot4 = "#e86a5c";
+export const dsColorDataPaletteApricot5 = "#f69958";
+export const dsColorDataPaletteApricot6 = "#f7c966";
+export const dsColorDataPaletteLime1 = "#131b60";
+export const dsColorDataPaletteLime2 = "#004a93";
+export const dsColorDataPaletteLime3 = "#0077ac";
+export const dsColorDataPaletteLime4 = "#00a3ac";
+export const dsColorDataPaletteLime5 = "#00cb9a";
+export const dsColorDataPaletteLime6 = "#a3ee87";
+export const dsColorDataPalettePlum1 = "#263995";
+export const dsColorDataPalettePlum2 = "#784496";
+export const dsColorDataPalettePlum3 = "#a85895";
+export const dsColorDataPalettePlum4 = "#ca7396";
+export const dsColorDataPalettePlum5 = "#e3949d";
+export const dsColorDataPalettePlum6 = "#f7bdad";
+export const dsColorDataScaleMango1 = "#1c7464";
+export const dsColorDataScaleMango2 = "#81b987";
+export const dsColorDataScaleMango3 = "#f1feaf";
+export const dsColorDataScaleMango4 = "#e7b657";
+export const dsColorDataScaleMango5 = "#dc6428";
+export const dsColorDataScalePear1 = "#c56077";
+export const dsColorDataScalePear2 = "#e7a491";
+export const dsColorDataScalePear3 = "#ffead0";
+export const dsColorDataScalePear4 = "#ecc188";
+export const dsColorDataScalePear5 = "#d49c44";
+export const dsColorDataScaleRaspberry1 = "#04367c";
+export const dsColorDataScaleRaspberry2 = "#9a85b9";
+export const dsColorDataScaleRaspberry3 = "#ffe8ff";
+export const dsColorDataScaleRaspberry4 = "#d584ac";
+export const dsColorDataScaleRaspberry5 = "#a40444";

--- a/dist/js/data-colors.esm.js
+++ b/dist/js/data-colors.esm.js
@@ -1,56 +1,14 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
-export const dsColorDataHueBlue1 = "#0073b3";
-export const dsColorDataHueBlue2 = "#2e8dc3";
-export const dsColorDataHueBlue3 = "#51a7d2";
-export const dsColorDataHueBlue4 = "#74c1e0";
-export const dsColorDataHueBlue5 = "#98dbef";
-export const dsColorDataHueBlue6 = "#bef5ff";
-export const dsColorDataHueGreen1 = "#459036";
-export const dsColorDataHueGreen2 = "#64a652";
-export const dsColorDataHueGreen3 = "#82bb6f";
-export const dsColorDataHueGreen4 = "#9fd28c";
-export const dsColorDataHueGreen5 = "#bce8aa";
-export const dsColorDataHueGreen6 = "#daffc9";
-export const dsColorDataHueRed1 = "#cd3138";
-export const dsColorDataHueRed2 = "#da5550";
-export const dsColorDataHueRed3 = "#e57369";
-export const dsColorDataHueRed4 = "#ef8f84";
-export const dsColorDataHueRed5 = "#f8aba0";
-export const dsColorDataHueRed6 = "#ffc6bd";
-export const dsColorDataPaletteApricot1 = "#5a1d7e";
-export const dsColorDataPaletteApricot2 = "#9d2076";
-export const dsColorDataPaletteApricot3 = "#cb3e69";
-export const dsColorDataPaletteApricot4 = "#e86a5c";
-export const dsColorDataPaletteApricot5 = "#f69958";
-export const dsColorDataPaletteApricot6 = "#f7c966";
-export const dsColorDataPaletteLime1 = "#131b60";
-export const dsColorDataPaletteLime2 = "#004a93";
-export const dsColorDataPaletteLime3 = "#0077ac";
-export const dsColorDataPaletteLime4 = "#00a3ac";
-export const dsColorDataPaletteLime5 = "#00cb9a";
-export const dsColorDataPaletteLime6 = "#a3ee87";
-export const dsColorDataPalettePlum1 = "#263995";
-export const dsColorDataPalettePlum2 = "#784496";
-export const dsColorDataPalettePlum3 = "#a85895";
-export const dsColorDataPalettePlum4 = "#ca7396";
-export const dsColorDataPalettePlum5 = "#e3949d";
-export const dsColorDataPalettePlum6 = "#f7bdad";
-export const dsColorDataScaleMango1 = "#1c7464";
-export const dsColorDataScaleMango2 = "#81b987";
-export const dsColorDataScaleMango3 = "#f1feaf";
-export const dsColorDataScaleMango4 = "#e7b657";
-export const dsColorDataScaleMango5 = "#dc6428";
-export const dsColorDataScalePear1 = "#c56077";
-export const dsColorDataScalePear2 = "#e7a491";
-export const dsColorDataScalePear3 = "#ffead0";
-export const dsColorDataScalePear4 = "#ecc188";
-export const dsColorDataScalePear5 = "#d49c44";
-export const dsColorDataScaleRaspberry1 = "#04367c";
-export const dsColorDataScaleRaspberry2 = "#9a85b9";
-export const dsColorDataScaleRaspberry3 = "#ffe8ff";
-export const dsColorDataScaleRaspberry4 = "#d584ac";
-export const dsColorDataScaleRaspberry5 = "#a40444";
+export const dsColorRampDataHueBlue = ["#0073b3","#2e8dc3","#51a7d2","#74c1e0","#98dbef","#bef5ff"];
+export const dsColorRampDataHueGreen = ["#459036","#64a652","#82bb6f","#9fd28c","#bce8aa","#daffc9"];
+export const dsColorRampDataHueRed = ["#cd3138","#da5550","#e57369","#ef8f84","#f8aba0","#ffc6bd"];
+export const dsColorRampDataPaletteApricot = ["#5a1d7e","#9d2076","#cb3e69","#e86a5c","#f69958","#f7c966"];
+export const dsColorRampDataPaletteLime = ["#131b60","#004a93","#0077ac","#00a3ac","#00cb9a","#a3ee87"];
+export const dsColorRampDataPalettePlum = ["#263995","#784496","#a85895","#ca7396","#e3949d","#f7bdad"];
+export const dsColorRampDataScaleMango = ["#1c7464","#81b987","#f1feaf","#e7b657","#dc6428"];
+export const dsColorRampDataScalePear = ["#c56077","#e7a491","#ffead0","#ecc188","#d49c44"];
+export const dsColorRampDataScaleRaspberry = ["#04367c","#9a85b9","#ffe8ff","#d584ac","#a40444"];

--- a/dist/js/font-vars.esm.js
+++ b/dist/js/font-vars.esm.js
@@ -1,0 +1,21 @@
+/**
+ * Do not edit directly
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ */
+
+export const dsGlobalFontFamilyBase = "Arial, sans-serif";
+export const dsGlobalFontFamilyBrand = "\"Overpass\", \"Lato\", Arial, sans-serif";
+export const dsGlobalFontFamilyCode = "\"Inconsolata\", monospace";
+export const dsGlobalFontFamilyCustom = "\"Open Sans\", Arial, sans-serif";
+export const dsGlobalFontFamilyData = "\"Lato\", \"Open Sans\", Arial, sans-serif";
+export const dsGlobalFontSizeBase = "0.9375rem";
+export const dsGlobalFontWeightBrandLight = 300;
+export const dsGlobalFontWeightBrandRegular = 400;
+export const dsGlobalFontWeightBrandExtrabold = 800;
+export const dsGlobalFontWeightCustomLight = 300;
+export const dsGlobalFontWeightCustomRegular = 400;
+export const dsGlobalFontWeightCustomSemibold = 600;
+export const dsGlobalFontWeightCustomBold = 700;
+export const dsGlobalFontWeightDataRegular = 400;
+export const dsGlobalFontWeightDataBold = 700;
+export const dsGlobalFontWeightDataBlack = 900;

--- a/dist/js/font-vars.esm.js
+++ b/dist/js/font-vars.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 export const dsGlobalFontFamilyBase = "Arial, sans-serif";

--- a/dist/js/layout.esm.js
+++ b/dist/js/layout.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 export const dsLayoutSizeSmall = "8px";

--- a/dist/js/layout.esm.js
+++ b/dist/js/layout.esm.js
@@ -1,0 +1,10 @@
+/**
+ * Do not edit directly
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ */
+
+export const dsLayoutSizeSmall = "8px";
+export const dsLayoutSizeMedium = "16px";
+export const dsLayoutSizeLarge = "24px";
+export const dsLayoutSizeExtraLarge = "32px";
+export const dsLayoutGridBase = "8px;";

--- a/dist/js/system-colors.esm.js
+++ b/dist/js/system-colors.esm.js
@@ -1,0 +1,19 @@
+/**
+ * Do not edit directly
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ */
+
+export const dsColorSystemBlack = "#000000";
+export const dsColorSystemBlue = "#0a75e3";
+export const dsColorSystemBlueDark = "#07529f";
+export const dsColorSystemBlueLight = "#d2ebff";
+export const dsColorSystemGreen = "#1f9b85"; // affirmative
+export const dsColorSystemGreenDark = "#166c5d";
+export const dsColorSystemGreenLight = "#ccf5eb";
+export const dsColorSystemOrange = "#dc7c24"; // medium risk
+export const dsColorSystemOrangeDark = "#9a5719";
+export const dsColorSystemOrangeLight = "#ffe6c8";
+export const dsColorSystemRed = "#e02929"; // destructive - high risk
+export const dsColorSystemRedDark = "#9d1d1d";
+export const dsColorSystemRedLight = "#ffe1e8";
+export const dsColorSystemWhite = "#ffffff";

--- a/dist/js/system-colors.esm.js
+++ b/dist/js/system-colors.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 export const dsColorSystemBlack = "#000000";

--- a/dist/js/theme.esm.js
+++ b/dist/js/theme.esm.js
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 export const dsThemeLightBg = "#ffffff";

--- a/dist/js/theme.esm.js
+++ b/dist/js/theme.esm.js
@@ -1,0 +1,9 @@
+/**
+ * Do not edit directly
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ */
+
+export const dsThemeLightBg = "#ffffff";
+export const dsThemeLightFg = "#2f3542";
+export const dsThemeDarkBg = "#21252e";
+export const dsThemeDarkFg = "#ffffff";

--- a/dist/less/brand-colors.less
+++ b/dist/less/brand-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 @ds-color-brand-dahlia: #ec0041;

--- a/dist/less/brand-colors.less
+++ b/dist/less/brand-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 @ds-color-brand-dahlia: #ec0041;

--- a/dist/less/code-colors.less
+++ b/dist/less/code-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 @ds-color-code-background: #2f3542;

--- a/dist/less/code-colors.less
+++ b/dist/less/code-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 @ds-color-code-background: #2f3542;

--- a/dist/less/data-colors.less
+++ b/dist/less/data-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 @ds-color-data-hue-blue-1: #0073b3;

--- a/dist/less/data-colors.less
+++ b/dist/less/data-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 @ds-color-data-hue-blue-1: #0073b3;

--- a/dist/less/font-vars.less
+++ b/dist/less/font-vars.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 @ds-global-font-family-base: Arial, sans-serif;

--- a/dist/less/font-vars.less
+++ b/dist/less/font-vars.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 @ds-global-font-family-base: Arial, sans-serif;

--- a/dist/less/layout.less
+++ b/dist/less/layout.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 @ds-layout-size-small: 8px;

--- a/dist/less/layout.less
+++ b/dist/less/layout.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 @ds-layout-size-small: 8px;

--- a/dist/less/system-colors.less
+++ b/dist/less/system-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 @ds-color-system-black: #000000;

--- a/dist/less/system-colors.less
+++ b/dist/less/system-colors.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 @ds-color-system-black: #000000;

--- a/dist/less/theme.less
+++ b/dist/less/theme.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 @ds-theme-light-bg: #ffffff;

--- a/dist/less/theme.less
+++ b/dist/less/theme.less
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 @ds-theme-light-bg: #ffffff;

--- a/dist/scss/brand-colors.scss
+++ b/dist/scss/brand-colors.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 $ds-color-brand-dahlia: #ec0041;

--- a/dist/scss/brand-colors.scss
+++ b/dist/scss/brand-colors.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 $ds-color-brand-dahlia: #ec0041;

--- a/dist/scss/code-colors.scss
+++ b/dist/scss/code-colors.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 $ds-color-code-background: #2f3542;

--- a/dist/scss/code-colors.scss
+++ b/dist/scss/code-colors.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 $ds-color-code-background: #2f3542;

--- a/dist/scss/data-colors.scss
+++ b/dist/scss/data-colors.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 $ds-color-data-hue-blue-1: #0073b3;

--- a/dist/scss/data-colors.scss
+++ b/dist/scss/data-colors.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 $ds-color-data-hue-blue-1: #0073b3;

--- a/dist/scss/font-vars.scss
+++ b/dist/scss/font-vars.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 $ds-global-font-family-base: Arial, sans-serif;

--- a/dist/scss/font-vars.scss
+++ b/dist/scss/font-vars.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 $ds-global-font-family-base: Arial, sans-serif;

--- a/dist/scss/layout.scss
+++ b/dist/scss/layout.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 $ds-layout-size-small: 8px;

--- a/dist/scss/layout.scss
+++ b/dist/scss/layout.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 $ds-layout-size-small: 8px;

--- a/dist/scss/system-colors.scss
+++ b/dist/scss/system-colors.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 $ds-color-system-black: #000000;

--- a/dist/scss/system-colors.scss
+++ b/dist/scss/system-colors.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 $ds-color-system-black: #000000;

--- a/dist/scss/theme.scss
+++ b/dist/scss/theme.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 17 Feb 2021 20:57:06 GMT
+ * Generated on Wed, 24 Feb 2021 12:22:30 GMT
  */
 
 $ds-theme-light-bg: #ffffff;

--- a/dist/scss/theme.scss
+++ b/dist/scss/theme.scss
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Wed, 24 Feb 2021 12:22:30 GMT
+ * Generated on Thu, 25 Feb 2021 13:32:57 GMT
  */
 
 $ds-theme-light-bg: #ffffff;

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "8.0.0",
+  "version": "8.1.0",
   "name": "@design/jw-design-library",
   "description": "A design library of global styles and icons for JW Player products",
   "license": "ISC",


### PR DESCRIPTION
- Fixed missing exports in CSS and JS. Some files were missing in the CSS and JS exports.
- Fixed `ramp` type in data-colors for JS.
- Fixed naming discrepancy between fonts and font-vars. LESS and SCSS were using `fonts`, while `fonts` was also being used for the actual @font-face rules. I ensured all exports are now using `font-vars` for the actual variables. This will break existing imports that use `fonts.[ext]`. They'll need to be renamed to `font-vars.[ext]`.

