### PR TITLE
Fix file extensions

### DIFF
--- a/config/js.yaml
+++ b/config/js.yaml
@@ -4,7 +4,7 @@ platforms:
     transformGroup: js
     prefix: ds
     files:
-      - destination: brand-colors.esm.js
+      - destination: brand-colors.mjs
         format: javascript/es6
         filter:
           attributes:
@@ -18,7 +18,7 @@ platforms:
             category: color
             type: brand
 
-      - destination: data-colors.esm.js
+      - destination: data-colors.mjs
         format: javascript/es6
         filter:
           attributes:
@@ -32,7 +32,7 @@ platforms:
             category: color
             type: ramp
 
-      - destination: system-colors.esm.js
+      - destination: system-colors.mjs
         format: javascript/es6
         filter:
           attributes:
@@ -46,7 +46,7 @@ platforms:
             category: color
             type: system
 
-      - destination: code-colors.esm.js
+      - destination: code-colors.mjs
         format: javascript/es6
         filter:
           attributes:
@@ -60,7 +60,7 @@ platforms:
             category: color
             type: code
 
-      - destination: font-vars.esm.js
+      - destination: font-vars.mjs
         format: javascript/es6
         filter:
           attributes:
@@ -74,7 +74,7 @@ platforms:
             category: global
             type: font
 
-      - destination: layout.esm.js
+      - destination: layout.mjs
         format: javascript/es6
         filter:
           attributes:
@@ -86,7 +86,7 @@ platforms:
           attributes:
             category: layout
 
-      - destination: theme.esm.js
+      - destination: theme.mjs
         format: javascript/es6
         filter:
           attributes:

--- a/dist/css/brand-colors.css
+++ b/dist/css/brand-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:33 GMT
  */
 
 :root {

--- a/dist/css/code-colors.css
+++ b/dist/css/code-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:33 GMT
  */
 
 :root {

--- a/dist/css/data-colors.css
+++ b/dist/css/data-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:33 GMT
  */
 
 :root {

--- a/dist/css/font-vars.css
+++ b/dist/css/font-vars.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:33 GMT
  */
 
 :root {

--- a/dist/css/layout.css
+++ b/dist/css/layout.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:33 GMT
  */
 
 :root {

--- a/dist/css/system-colors.css
+++ b/dist/css/system-colors.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:33 GMT
  */
 
 :root {

--- a/dist/css/theme.css
+++ b/dist/css/theme.css
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:33 GMT
  */
 
 :root {

--- a/dist/js/brand-colors.d.ts
+++ b/dist/js/brand-colors.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsColorBrandDahlia : string;

--- a/dist/js/brand-colors.mjs
+++ b/dist/js/brand-colors.mjs
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsColorBrandDahlia = "#ec0041";

--- a/dist/js/code-colors.d.ts
+++ b/dist/js/code-colors.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsColorCodeBackground : string;

--- a/dist/js/code-colors.mjs
+++ b/dist/js/code-colors.mjs
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsColorCodeBackground = "#2f3542";

--- a/dist/js/data-colors.d.ts
+++ b/dist/js/data-colors.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsColorRampDataHueBlue : string[];

--- a/dist/js/data-colors.mjs
+++ b/dist/js/data-colors.mjs
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsColorRampDataHueBlue = ["#0073b3","#2e8dc3","#51a7d2","#74c1e0","#98dbef","#bef5ff"];

--- a/dist/js/font-vars.d.ts
+++ b/dist/js/font-vars.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsGlobalFontFamilyBase : string;

--- a/dist/js/font-vars.mjs
+++ b/dist/js/font-vars.mjs
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsGlobalFontFamilyBase = "Arial, sans-serif";

--- a/dist/js/layout.d.ts
+++ b/dist/js/layout.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsLayoutSizeSmall : string;

--- a/dist/js/layout.mjs
+++ b/dist/js/layout.mjs
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsLayoutSizeSmall = "8px";

--- a/dist/js/system-colors.d.ts
+++ b/dist/js/system-colors.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsColorSystemBlack : string;

--- a/dist/js/system-colors.mjs
+++ b/dist/js/system-colors.mjs
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsColorSystemBlack = "#000000";

--- a/dist/js/theme.d.ts
+++ b/dist/js/theme.d.ts
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsThemeLightBg : string;

--- a/dist/js/theme.mjs
+++ b/dist/js/theme.mjs
@@ -1,6 +1,6 @@
 /**
  * Do not edit directly
- * Generated on Mon, 09 May 2022 13:56:15 GMT
+ * Generated on Thu, 12 May 2022 12:25:34 GMT
  */
 
 export const dsThemeLightBg = "#ffffff";

--- a/dist/less/brand-colors.less
+++ b/dist/less/brand-colors.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 @ds-color-brand-dahlia: #ec0041;
 @ds-color-brand-dahlia-fade: #fbccd9;

--- a/dist/less/code-colors.less
+++ b/dist/less/code-colors.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 @ds-color-code-background: #2f3542;
 @ds-color-code-background-inline: #f3f5f8;

--- a/dist/less/data-colors.less
+++ b/dist/less/data-colors.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 @ds-color-data-hue-blue-1: #0073b3;
 @ds-color-data-hue-blue-2: #2e8dc3;

--- a/dist/less/font-vars.less
+++ b/dist/less/font-vars.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 @ds-global-font-family-base: Arial, sans-serif;
 @ds-global-font-family-brand: "Overpass", "Lato", Arial, sans-serif;

--- a/dist/less/layout.less
+++ b/dist/less/layout.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 @ds-layout-size-small: 8px;
 @ds-layout-size-medium: 16px;

--- a/dist/less/system-colors.less
+++ b/dist/less/system-colors.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 @ds-color-system-black: #000000;
 @ds-color-system-blue: #0a75e3;

--- a/dist/less/theme.less
+++ b/dist/less/theme.less
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 @ds-theme-light-bg: #ffffff;
 @ds-theme-light-fg: #2f3542;

--- a/dist/scss/brand-colors.scss
+++ b/dist/scss/brand-colors.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 $ds-color-brand-dahlia: #ec0041;
 $ds-color-brand-dahlia-fade: #fbccd9;

--- a/dist/scss/code-colors.scss
+++ b/dist/scss/code-colors.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 $ds-color-code-background: #2f3542;
 $ds-color-code-background-inline: #f3f5f8;

--- a/dist/scss/data-colors.scss
+++ b/dist/scss/data-colors.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 $ds-color-data-hue-blue-1: #0073b3;
 $ds-color-data-hue-blue-2: #2e8dc3;

--- a/dist/scss/font-vars.scss
+++ b/dist/scss/font-vars.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 $ds-global-font-family-base: Arial, sans-serif;
 $ds-global-font-family-brand: "Overpass", "Lato", Arial, sans-serif;

--- a/dist/scss/layout.scss
+++ b/dist/scss/layout.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 $ds-layout-size-small: 8px;
 $ds-layout-size-medium: 16px;

--- a/dist/scss/system-colors.scss
+++ b/dist/scss/system-colors.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 $ds-color-system-black: #000000;
 $ds-color-system-blue: #0a75e3;

--- a/dist/scss/theme.scss
+++ b/dist/scss/theme.scss
@@ -1,6 +1,6 @@
 
 // Do not edit directly
-// Generated on Mon, 09 May 2022 13:56:15 GMT
+// Generated on Thu, 12 May 2022 12:25:34 GMT
 
 $ds-theme-light-bg: #ffffff;
 $ds-theme-light-fg: #2f3542;


### PR DESCRIPTION
Sorry @kimhart . Turns out that TS won't pick up the `.d.ts` files for the `.esm.js` extensions. Renamed to `.mjs` since it's the official extension for ES modules. Tested it locally and this does work in combination with TypeScript.